### PR TITLE
Update balance button styling and fix free searches count

### DIFF
--- a/client/components/layout/Header.tsx
+++ b/client/components/layout/Header.tsx
@@ -62,19 +62,20 @@ export function Header() {
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <button
-                    className="hidden sm:inline-flex items-center gap-2 rounded-full border border-border bg-card/70 px-3 py-1 text-sm hover:bg-accent"
+                    className="relative overflow-visible hidden sm:inline-flex items-center gap-2 rounded-full border border-border bg-card/80 px-3 py-1 text-sm hover:bg-accent shadow-[0_0_20px_rgba(234,179,8,0.35)] ring-1 ring-amber-400/50"
                     title="Searches remaining"
                   >
                     <span
-                      className="max-w-[12rem] truncate"
-                      title={profile?.name || profile?.email || undefined}
-                    >
-                      {profile?.name || profile?.email || "Account"}
-                    </span>
-                    <span className="inline-flex items-center gap-1 rounded-full bg-brand-500/10 text-brand-700 dark:text-brand-300 px-2 py-0.5 text-xs font-semibold">
-                      {typeof profile?.totalSearchesRemaining === "number"
-                        ? profile.totalSearchesRemaining
-                        : 0}
+                      aria-hidden
+                      className="pointer-events-none absolute -inset-0.5 rounded-full bg-[conic-gradient(from_0deg,rgba(251,191,36,0.25),rgba(245,158,11,0.6),rgba(217,119,6,0.5),rgba(251,191,36,0.25))] blur-md opacity-70 animate-[spin_6s_linear_infinite]"
+                    />
+                    <span className="relative z-10 inline-flex items-center gap-2">
+                      <span className="max-w-[12rem] truncate font-semibold">Balance</span>
+                      <span className="inline-flex items-center gap-1 rounded-full bg-brand-500/10 text-brand-700 dark:text-brand-300 px-2 py-0.5 text-xs font-semibold">
+                        {typeof profile?.totalSearchesRemaining === "number"
+                          ? profile.totalSearchesRemaining
+                          : 0}
+                      </span>
                     </span>
                   </button>
                 </DropdownMenuTrigger>

--- a/client/components/layout/Header.tsx
+++ b/client/components/layout/Header.tsx
@@ -70,7 +70,9 @@ export function Header() {
                       className="pointer-events-none absolute -inset-0.5 rounded-full bg-[conic-gradient(from_0deg,rgba(251,191,36,0.25),rgba(245,158,11,0.6),rgba(217,119,6,0.5),rgba(251,191,36,0.25))] blur-md opacity-70 animate-[spin_6s_linear_infinite]"
                     />
                     <span className="relative z-10 inline-flex items-center gap-2">
-                      <span className="max-w-[12rem] truncate font-semibold">Balance</span>
+                      <span className="max-w-[12rem] truncate font-semibold">
+                        Balance
+                      </span>
                       <span className="inline-flex items-center gap-1 rounded-full bg-brand-500/10 text-brand-700 dark:text-brand-300 px-2 py-0.5 text-xs font-semibold">
                         {typeof profile?.totalSearchesRemaining === "number"
                           ? profile.totalSearchesRemaining

--- a/client/lib/user.ts
+++ b/client/lib/user.ts
@@ -89,10 +89,10 @@ export async function ensureUserDoc(
       username,
       role: "user",
       uniquePurchaseId,
-      freeSearches: 3,
+      freeSearches: 2,
       purchasedSearches: 0,
       usedSearches: 0,
-      totalSearchesRemaining: 3,
+      totalSearchesRemaining: 2,
       createdAt: serverTimestamp(),
       updatedAt: serverTimestamp(),
     };

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -420,10 +420,10 @@ function AdjustModal({
           totalSearchesRemaining: newRemaining,
         });
       } else if (mode === "resetFree") {
-        const delta = 3 - (user.freeSearches ?? 0);
+        const delta = 2 - (user.freeSearches ?? 0);
         const newRemaining = (user.totalSearchesRemaining ?? 0) + delta;
         await updateDoc(ref, {
-          freeSearches: 3,
+          freeSearches: 2,
           totalSearchesRemaining: newRemaining,
         });
       }
@@ -442,7 +442,7 @@ function AdjustModal({
           <DialogTitle className="font-black">
             {mode === "add" && "Add searches"}
             {mode === "deduct" && "Deduct searches"}
-            {mode === "resetFree" && "Reset free to 3"}
+            {mode === "resetFree" && "Reset free to 2"}
           </DialogTitle>
         </DialogHeader>
         {mode !== "resetFree" && (


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several UI/UX improvements and configuration fixes:
- User requested changing the account button label to "Balance" for better clarity
- User wanted a golden/yellowish glow effect around the balance button to make it more prominent
- User reported that new signups were not receiving the correct number of free searches (should be 2, not 3)
- User needed better visual indication of their search balance

## Code changes

**Header Component (`Header.tsx`)**:
- Changed button text from dynamic account name to static "Balance" label
- Added golden glow animation effect using CSS classes and conic gradient
- Enhanced button styling with shadow effects and ring borders
- Added spinning animation for the glow effect (6s linear infinite)
- Improved visual hierarchy with relative positioning and z-index

**User Management (`user.ts`)**:
- Updated default `freeSearches` from 3 to 2 for new user registration
- Updated default `totalSearchesRemaining` from 3 to 2 to match free searches

**Admin Panel (`Admin.tsx`)**:
- Updated free search reset functionality to use 2 instead of 3
- Updated admin modal text to reflect the new free search count (2)
- Ensured consistency across all free search references

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d3f7f7531d6645d99151b189fbbe647a/pixel-home)

👀 [Preview Link](https://d3f7f7531d6645d99151b189fbbe647a-pixel-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d3f7f7531d6645d99151b189fbbe647a</projectId>-->
<!--<branchName>pixel-home</branchName>-->