### PR TITLE
Fix Netlify routing to make all pages accessible

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,9 +7,14 @@
 [functions]
   external_node_modules = ["express"]
   node_bundler = "esbuild"
-  
+
 [[redirects]]
   force = true
   from = "/api/*"
   status = 200
   to = "/.netlify/functions/api/:splat"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
## Purpose
Fix Netlify configuration to ensure all pages are accessible by implementing proper client-side routing fallback.

## Code changes
- Added a catch-all redirect rule in `netlify.toml` that routes all unmatched paths (`/*`) to `/index.html` with a 200 status code
- This enables single-page application (SPA) routing to work correctly on Netlify by serving the main HTML file for all routes
- Removed trailing whitespace in the functions section

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d3f7f7531d6645d99151b189fbbe647a/echo-home)

👀 [Preview Link](https://d3f7f7531d6645d99151b189fbbe647a-echo-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d3f7f7531d6645d99151b189fbbe647a</projectId>-->
<!--<branchName>echo-home</branchName>-->