### PR TITLE
Fix profile glow animation and add sign out menu

### DIFF
--- a/client/components/layout/Header.tsx
+++ b/client/components/layout/Header.tsx
@@ -93,7 +93,10 @@ export function Header() {
                 <DropdownMenuTrigger asChild>
                   <button className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background">
                     <Avatar className="h-9 w-9 select-none">
-                      <AvatarImage src={user.photoURL || undefined} alt="User" />
+                      <AvatarImage
+                        src={user.photoURL || undefined}
+                        alt="User"
+                      />
                       <AvatarFallback>
                         <UserIcon className="h-5 w-5 opacity-70" />
                       </AvatarFallback>
@@ -105,9 +108,9 @@ export function Header() {
                     onSelect={async () => {
                       try {
                         await signOut();
-                        navigate('/');
+                        navigate("/");
                       } catch (e) {
-                        console.warn('Sign out failed', e);
+                        console.warn("Sign out failed", e);
                       }
                     }}
                   >

--- a/client/components/layout/Header.tsx
+++ b/client/components/layout/Header.tsx
@@ -22,7 +22,7 @@ const baseNavItems = [
 ];
 
 export function Header() {
-  const { user, profile } = useAuth();
+  const { user, profile, signOut } = useAuth();
   const navItems =
     profile?.role === "admin"
       ? [...baseNavItems, { to: "/admin", label: "Admin" }]
@@ -67,7 +67,7 @@ export function Header() {
                   >
                     <span
                       aria-hidden
-                      className="pointer-events-none absolute -inset-0.5 rounded-full bg-[conic-gradient(from_0deg,rgba(251,191,36,0.25),rgba(245,158,11,0.6),rgba(217,119,6,0.5),rgba(251,191,36,0.25))] blur-md opacity-70 animate-[spin_6s_linear_infinite]"
+                      className="pointer-events-none absolute -inset-0.5 rounded-full [mask:radial-gradient(farthest-side,transparent_calc(100%_-_3px),#000_calc(100%_-_0px))] bg-[conic-gradient(from_0deg,transparent_0deg,transparent_340deg,rgba(245,158,11,0.95)_350deg,transparent_360deg)] opacity-80 blur-[2px] animate-[spin_4s_linear_infinite]"
                     />
                     <span className="relative z-10 inline-flex items-center gap-2">
                       <span className="max-w-[12rem] truncate font-semibold">
@@ -88,13 +88,34 @@ export function Header() {
                 </DropdownMenuContent>
               </DropdownMenu>
 
-              {/* Non-clickable user avatar */}
-              <Avatar className="h-9 w-9 select-none">
-                <AvatarImage src={user.photoURL || undefined} alt="User" />
-                <AvatarFallback>
-                  <UserIcon className="h-5 w-5 opacity-70" />
-                </AvatarFallback>
-              </Avatar>
+              {/* User avatar with menu */}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background">
+                    <Avatar className="h-9 w-9 select-none">
+                      <AvatarImage src={user.photoURL || undefined} alt="User" />
+                      <AvatarFallback>
+                        <UserIcon className="h-5 w-5 opacity-70" />
+                      </AvatarFallback>
+                    </Avatar>
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onSelect={() => navigate('/profile')}>Profile</DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={async () => {
+                      try {
+                        await signOut();
+                        navigate('/');
+                      } catch (e) {
+                        console.warn('Sign out failed', e);
+                      }
+                    }}
+                  >
+                    Sign out
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           ) : (
             <Button onClick={() => navigate("/auth")} title="Sign in">

--- a/client/components/layout/Header.tsx
+++ b/client/components/layout/Header.tsx
@@ -101,7 +101,6 @@ export function Header() {
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
-                  <DropdownMenuItem onSelect={() => navigate('/profile')}>Profile</DropdownMenuItem>
                   <DropdownMenuItem
                     onSelect={async () => {
                       try {


### PR DESCRIPTION
## Purpose

The user wanted to improve the profile button's visual appearance by fixing the golden/yellow glow effect to shine or orbit the button's border in a constant manner instead of rotating like a fan. Additionally, they requested that clicking the profile icon should display a Sign Out button with working functionality.

## Code changes

- **Profile glow animation**: Modified the profile button's glow effect from a spinning conic gradient to a more subtle orbital shine using a radial mask and refined conic gradient that creates a smooth orbiting light effect
- **Sign out functionality**: Added `signOut` from `useAuth()` hook and converted the non-clickable user avatar into a clickable dropdown menu
- **User avatar dropdown**: Wrapped the avatar in a `DropdownMenu` component with proper focus states and accessibility
- **Sign out menu item**: Added a dropdown menu item that calls the `signOut` function and navigates to the home page, with error handling for failed sign out attempts

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d3f7f7531d6645d99151b189fbbe647a/quantum-hub)

👀 [Preview Link](https://d3f7f7531d6645d99151b189fbbe647a-quantum-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d3f7f7531d6645d99151b189fbbe647a</projectId>-->
<!--<branchName>quantum-hub</branchName>-->